### PR TITLE
WYSIWYG에 충실하기 위해 에디터에 나오는 폰트를 본문 폰트와 일치시키기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 ecosystem.config.cjs
 
 .idea/
+.vscode/
 
 .pnpm-debug.log
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"build": "vite build",
 		"start": "node run.js",
 		"package": "svelte-kit package",
-		"preview": "svelte-kit preview --port 60001",
+		"preview": "vite preview --port 60001",
 		"prepare": "svelte-kit sync",
 		"test": "playwright test",
 		"check": "svelte-check --tsconfig ./tsconfig.json",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@import url('/css/BinggraeMelona.css');
+@import url('static-folder/css/BinggraeMelona.css');
 
 @font-face {
   font-family: 'RIDIBatang';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,15 +1,4 @@
-@font-face {
-  font-family: 'BinggraeMelona';
-  src: url('https://s3.ru.hn/fonts/BinggraeMelona.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'BinggraeMelona'; /* 'Tanugo'; */
-  src: url("https://s3.ru.hn/fonts/umeboshi_.woff2") format('woff2');
-  unicode-range: U+4e00-9fbf, U+3040-309f, U+30A0-30FF;
-}
+@import url('/css/BinggraeMelona.css');
 
 @font-face {
   font-family: 'RIDIBatang';

--- a/static/css/BinggraeMelona.css
+++ b/static/css/BinggraeMelona.css
@@ -3,10 +3,10 @@
     src: url('https://s3.ru.hn/fonts/BinggraeMelona.woff2') format('woff2');
     font-weight: normal;
     font-style: normal;
-  }
+}
   
-  @font-face {
+@font-face {
     font-family: 'BinggraeMelona'; /* 'Tanugo'; */
     src: url("https://s3.ru.hn/fonts/umeboshi_.woff2") format('woff2');
     unicode-range: U+4e00-9fbf, U+3040-309f, U+30A0-30FF;
-  }
+}

--- a/static/css/BinggraeMelona.css
+++ b/static/css/BinggraeMelona.css
@@ -1,0 +1,12 @@
+@font-face {
+    font-family: 'BinggraeMelona';
+    src: url('https://s3.ru.hn/fonts/BinggraeMelona.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+  }
+  
+  @font-face {
+    font-family: 'BinggraeMelona'; /* 'Tanugo'; */
+    src: url("https://s3.ru.hn/fonts/umeboshi_.woff2") format('woff2');
+    unicode-range: U+4e00-9fbf, U+3040-309f, U+30A0-30FF;
+  }

--- a/static/editor.css
+++ b/static/editor.css
@@ -10,3 +10,21 @@ img {
 p {
   margin: 0.25rem 0 !important;
 }
+
+@font-face {
+  font-family: 'BinggraeMelona';
+  src: url('https://s3.ru.hn/fonts/BinggraeMelona.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'BinggraeMelona'; /* 'Tanugo'; */
+  src: url("https://s3.ru.hn/fonts/umeboshi_.woff2") format('woff2');
+  unicode-range: U+4e00-9fbf, U+3040-309f, U+30A0-30FF;
+}
+
+
+* {
+  font-family: BinggraeMelona,sans-serif;
+}

--- a/static/editor.css
+++ b/static/editor.css
@@ -24,7 +24,6 @@ p {
   unicode-range: U+4e00-9fbf, U+3040-309f, U+30A0-30FF;
 }
 
-
 * {
   font-family: BinggraeMelona,sans-serif;
 }

--- a/static/editor.css
+++ b/static/editor.css
@@ -1,3 +1,5 @@
+@import url('/css/BinggraeMelona.css');
+
 body {
   padding: 1rem;
 }
@@ -10,8 +12,6 @@ img {
 p {
   margin: 0.25rem 0 !important;
 }
-
-@import url('/css/BinggraeMelona.css');
 
 * {
   font-family: BinggraeMelona,sans-serif;

--- a/static/editor.css
+++ b/static/editor.css
@@ -11,18 +11,7 @@ p {
   margin: 0.25rem 0 !important;
 }
 
-@font-face {
-  font-family: 'BinggraeMelona';
-  src: url('https://s3.ru.hn/fonts/BinggraeMelona.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'BinggraeMelona'; /* 'Tanugo'; */
-  src: url("https://s3.ru.hn/fonts/umeboshi_.woff2") format('woff2');
-  unicode-range: U+4e00-9fbf, U+3040-309f, U+30A0-30FF;
-}
+@import url('/css/BinggraeMelona.css');
 
 * {
   font-family: BinggraeMelona,sans-serif;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,7 +13,10 @@ const config = {
     adapter: adapter({
       out: './build',
     }),
-  },
+    alias: {
+      'static-folder': 'static'
+    }
+  }
 };
 
 export default config;


### PR DESCRIPTION
지금 에디터 폰트가 본문 폰트와 일치되지 않은 현상이 있어서 What You See Is What You Get 즉, 위즈위그 원칙에 어긋나는데 해당 문제를 해결했습니다.

https://www.tiny.cloud/blog/how-to-change-the-default-font-family-size-and-color-in-tinymce/ 이글 참조해서 수정했습니다.